### PR TITLE
Descriptor change for RISC and powerpc 

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -194,6 +194,7 @@ script: |
     case $i in
        aarch64-*) : ;;
        arm-*) : ;;
+       riscv64*) : ;;
        *) make ${MAKEOPTS} -C src check-symbols ;;
     esac
 

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -195,6 +195,7 @@ script: |
        aarch64-*) : ;;
        arm-*) : ;;
        riscv64*) : ;;
+       powerpc64le*) : ;;
        *) make ${MAKEOPTS} -C src check-symbols ;;
     esac
 


### PR DESCRIPTION
Have added RISCV64 and powerpc64le to the list in the workaround in commit https://github.com/cryptolinux/ion/commit/9d25b6fec7256b8f4086ae0e82b0fe5880d4a841