### PR TITLE
Update to use bls-dash for protx/bls functions

### DIFF
--- a/depends/packages/bls-dash.mk
+++ b/depends/packages/bls-dash.mk
@@ -1,0 +1,73 @@
+package=bls-dash
+$(package)_version=1.1.0
+$(package)_download_path=https://github.com/dashpay/bls-signatures/archive
+$(package)_download_file=$($(package)_version).tar.gz
+$(package)_file_name=$(package)-$($(package)_download_file)
+$(package)_build_subdir=build
+$(package)_sha256_hash=276c8573104e5f18bb5b9fd3ffd49585dda5ba5f6de2de74759dda8ca5a9deac
+$(package)_dependencies=gmp
+
+$(package)_relic_version=3a23142be0a5510a3aa93cd6c76fc59d3fc732a5
+$(package)_relic_download_path=https://github.com/relic-toolkit/relic/archive
+$(package)_relic_download_file=$($(package)_relic_version).tar.gz
+$(package)_relic_file_name=relic-toolkit-$($(package)_relic_download_file)
+$(package)_relic_build_subdir=relic
+$(package)_relic_sha256_hash=ddad83b1406985a1e4703bd03bdbab89453aa700c0c99567cf8de51c205e5dde
+
+$(package)_extra_sources=$($(package)_relic_file_name)
+
+define $(package)_fetch_cmds
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_relic_download_path),$($(package)_relic_download_file),$($(package)_relic_file_name),$($(package)_relic_sha256_hash))
+endef
+
+define $(package)_extract_cmds
+  mkdir -p $($(package)_extract_dir) && \
+  echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_relic_sha256_hash)  $($(package)_source_dir)/$($(package)_relic_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  $(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  tar --strip-components=1 -xf $($(package)_source) -C . && \
+  cp $($(package)_source_dir)/$($(package)_relic_file_name) .
+endef
+
+define $(package)_set_vars
+  $(package)_config_opts=-DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)/$(host_prefix)
+  $(package)_config_opts+= -DCMAKE_PREFIX_PATH=$(host_prefix)
+  $(package)_config_opts+= -DSTLIB=ON -DSHLIB=OFF -DSTBIN=ON
+  $(package)_config_opts+= -DBUILD_BLS_PYTHON_BINDINGS=0 -DBUILD_BLS_TESTS=0 -DBUILD_BLS_BENCHMARKS=0
+  $(package)_config_opts_linux=-DOPSYS=LINUX -DCMAKE_SYSTEM_NAME=Linux
+  $(package)_config_opts_darwin=-DOPSYS=MACOSX -DCMAKE_SYSTEM_NAME=Darwin
+  $(package)_config_opts_mingw32=-DOPSYS=WINDOWS -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SHARED_LIBRARY_LINK_C_FLAGS=""
+  $(package)_config_opts_i686+= -DWSIZE=32
+  $(package)_config_opts_x86_64+= -DWSIZE=64
+  $(package)_config_opts_arm+= -DWSIZE=32
+  $(package)_config_opts_armv7l+= -DWSIZE=32
+  $(package)_config_opts_debug=-DDEBUG=ON -DCMAKE_BUILD_TYPE=Debug
+
+  ifneq ($(darwin_native_toolchain),)
+    $(package)_config_opts_darwin+= -DCMAKE_AR="$(host_prefix)/native/bin/$($(package)_ar)"
+    $(package)_config_opts_darwin+= -DCMAKE_RANLIB="$(host_prefix)/native/bin/$($(package)_ranlib)"
+  endif
+endef
+
+define $(package)_preprocess_cmds
+  sed -i.old "s|GIT_REPOSITORY https://github.com/relic-toolkit/relic.git|URL \"../../relic-toolkit-$($(package)_relic_version).tar.gz\"|" src/CMakeLists.txt && \
+  sed -i.old "s|GIT_TAG        .*RELIC_GIT_TAG.*|URL_HASH SHA256=$($(package)_relic_sha256_hash)|" src/CMakeLists.txt
+endef
+
+define $(package)_config_cmds
+  export CC="$($(package)_cc)" && \
+  export CXX="$($(package)_cxx)" && \
+  export CFLAGS="$($(package)_cflags) $($(package)_cppflags)" && \
+  export CXXFLAGS="$($(package)_cxxflags) $($(package)_cppflags)" && \
+  export LDFLAGS="$($(package)_ldflags)" && \
+  cmake ../ $($(package)_config_opts)
+endef
+
+define $(package)_build_cmds
+  $(MAKE) $($(package)_build_opts)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) install
+endef

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages:=boost openssl libevent gmp chia_bls backtrace
+packages:=boost openssl libevent gmp bls-dash backtrace
 
 qt_native_packages = native_protobuf
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -15,6 +15,7 @@ $(package)_patches+=xkb-default.patch no-xlib.patch
 $(package)_patches+=fix_android_qmake_conf.patch fix_android_jni_static.patch
 # NOTE: fix_qt_configure.patch is only needed for Qt 5.7, newer versions don't have this issue.
 # Remove it after bumping $(package)_version to 5.8+.
+$(package)_patches+=force_bootstrap.patch qbytearry.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=fb5a47799754af73d3bf501fe513342cfe2fc37f64e80df5533f6110e804220c
@@ -198,8 +199,10 @@ define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/fix_no_printer.patch &&\
   patch -p1 < $($(package)_patch_dir)/fix_rcc_determinism.patch &&\
   patch -p1 < $($(package)_patch_dir)/xkb-default.patch &&\
+  patch -p1 < $($(package)_patch_dir)/qbytearry.patch &&\
   patch -p1 -i $($(package)_patch_dir)/fix_android_qmake_conf.patch &&\
   patch -p1 -i $($(package)_patch_dir)/fix_android_jni_static.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/force_bootstrap.patch &&\
   echo "!host_build: QMAKE_CFLAGS     += $($(package)_cflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf &&\
   echo "!host_build: QMAKE_CXXFLAGS   += $($(package)_cxxflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf &&\
   echo "!host_build: QMAKE_LFLAGS     += $($(package)_ldflags)" >> qtbase/mkspecs/common/gcc-base.conf &&\

--- a/depends/packages/xcb_proto.mk
+++ b/depends/packages/xcb_proto.mk
@@ -3,6 +3,7 @@ $(package)_version=1.13
 $(package)_download_path=http://xcb.freedesktop.org/dist
 $(package)_file_name=xcb-proto-$($(package)_version).tar.bz2
 $(package)_sha256_hash=7b98721e669be80284e9bbfeab02d2d0d54cd11172b72271e47a2fe875e2bde1
+$(package)_patches=0001-xcb-proto-for-new-python.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared
@@ -10,6 +11,7 @@ define $(package)_set_vars
 endef
 
 define $(package)_preprocess_cmds
+patch -p1 < $($(package)_patch_dir)/0001-xcb-proto-for-new-python.patch && \
   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub .
 endef
 

--- a/depends/patches/qt/force_bootstrap.patch
+++ b/depends/patches/qt/force_bootstrap.patch
@@ -1,0 +1,16 @@
+Qt lrelease tool depends on XML features.
+No need to build the libQt5Xml module if tools are
+bootstrapped, even if not cross-compiling.
+
+--- old/qtbase/mkspecs/features/qt_build_config.prf
++++ new/qtbase/mkspecs/features/qt_build_config.prf
+@@ -82,8 +82,7 @@
+ !prefix_build: \
+     CONFIG += qt_clear_installs
+ 
+-cross_compile: \
+-    CONFIG += force_bootstrap
++CONFIG += force_bootstrap
+ 
+ android|uikit|winrt: \
+     CONFIG += builtin_testdata

--- a/depends/patches/qt/qbytearry.patch
+++ b/depends/patches/qt/qbytearry.patch
@@ -1,0 +1,12 @@
+--- 5.9.8-6fc4ed28961/qtbase/src/corelib/tools/qbytearray.h.orig	2021-06-17 15:43:00.880280809 +0100
++++ 5.9.8-6fc4ed28961/qtbase/src/corelib/tools/qbytearray.h	2021-06-17 15:43:31.703740899 +0100
+@@ -52,6 +52,9 @@
+ #include <string>
+ #include <iterator>
+ 
++#include <limits>
++#include <algorithm>
++
+ #ifdef truncate
+ #error qbytearray.h must be included before any header file that defines truncate
+ #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,7 +43,7 @@ BITCOIN_INCLUDES=-I$(builddir) $(BDB_CPPFLAGS) $(BOOST_CPPFLAGS) $(LEVELDB_CPPFL
 BITCOIN_INCLUDES += -I$(srcdir)/secp256k1/include
 BITCOIN_INCLUDES += $(UNIVALUE_CFLAGS)
 
-BLS_LIBS=-lchiabls -lgmp
+BLS_LIBS=-lbls-dash -lgmp
 
 LIBBITCOIN_SERVER=libion_server.a
 LIBBITCOIN_COMMON=libion_common.a

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -1,11 +1,9 @@
-// Copyright (c) 2018-2019 The Dash Core developers
-// Copyright (c) 2018-2020 The Ion Core developers
+// Copyright (c) 2018-2021 The Dash Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bls/bls.h>
 
-#include <hash.h>
 #include <random.h>
 #include <tinyformat.h>
 
@@ -16,67 +14,26 @@
 #include <assert.h>
 #include <string.h>
 
-bool CBLSId::InternalSetBuf(const void* buf)
+static std::unique_ptr<bls::CoreMPL> pSchemeLegacy(new bls::LegacySchemeMPL);
+static std::unique_ptr<bls::CoreMPL> pScheme(new bls::BasicSchemeMPL);
+
+static std::unique_ptr<bls::CoreMPL>& Scheme(const bool fLegacy)
 {
-    memcpy(impl.begin(), buf, sizeof(uint256));
-    return true;
+    return fLegacy ? pSchemeLegacy : pScheme;
 }
 
-bool CBLSId::InternalGetBuf(void* buf) const
+CBLSId::CBLSId(const uint256& nHash) : CBLSWrapper<CBLSIdImplicit, BLS_CURVE_ID_SIZE, CBLSId>()
 {
-    memcpy(buf, impl.begin(), sizeof(uint256));
-    return true;
-}
-
-void CBLSId::SetInt(int x)
-{
-    impl.SetHex(strprintf("%x", x));
+    impl = nHash;
     fValid = true;
-    UpdateHash();
-}
-
-void CBLSId::SetHash(const uint256& hash)
-{
-    impl = hash;
-    fValid = true;
-    UpdateHash();
-}
-
-CBLSId CBLSId::FromInt(int64_t i)
-{
-    CBLSId id;
-    id.SetInt(i);
-    return id;
-}
-
-CBLSId CBLSId::FromHash(const uint256& hash)
-{
-    CBLSId id;
-    id.SetHash(hash);
-    return id;
-}
-
-bool CBLSSecretKey::InternalSetBuf(const void* buf)
-{
-    try {
-        impl = bls::PrivateKey::FromBytes((const uint8_t*)buf);
-        return true;
-    } catch (...) {
-        return false;
-    }
-}
-
-bool CBLSSecretKey::InternalGetBuf(void* buf) const
-{
-    impl.Serialize((uint8_t*)buf);
-    return true;
+    cachedHash.SetNull();
 }
 
 void CBLSSecretKey::AggregateInsecure(const CBLSSecretKey& o)
 {
     assert(IsValid() && o.IsValid());
-    impl = bls::PrivateKey::AggregateInsecure({impl, o.impl});
-    UpdateHash();
+    impl = bls::PrivateKey::Aggregate({impl, o.impl});
+    cachedHash.SetNull();
 }
 
 CBLSSecretKey CBLSSecretKey::AggregateInsecure(const std::vector<CBLSSecretKey>& sks)
@@ -91,11 +48,10 @@ CBLSSecretKey CBLSSecretKey::AggregateInsecure(const std::vector<CBLSSecretKey>&
         v.emplace_back(sk.impl);
     }
 
-    auto agg = bls::PrivateKey::AggregateInsecure(v);
     CBLSSecretKey ret;
-    ret.impl = agg;
+    ret.impl = bls::PrivateKey::Aggregate(v);
     ret.fValid = true;
-    ret.UpdateHash();
+    ret.cachedHash.SetNull();
     return ret;
 }
 
@@ -106,20 +62,20 @@ void CBLSSecretKey::MakeNewKey()
     while (true) {
         GetStrongRandBytes(buf, sizeof(buf));
         try {
-            impl = bls::PrivateKey::FromBytes((const uint8_t*)buf);
+            impl = bls::PrivateKey::FromBytes(bls::Bytes((const uint8_t*)buf, SerSize));
             break;
         } catch (...) {
         }
     }
     fValid = true;
-    UpdateHash();
+    cachedHash.SetNull();
 }
 #endif
 
 bool CBLSSecretKey::SecretKeyShare(const std::vector<CBLSSecretKey>& msk, const CBLSId& _id)
 {
     fValid = false;
-    UpdateHash();
+    cachedHash.SetNull();
 
     if (!_id.IsValid()) {
         return false;
@@ -135,13 +91,13 @@ bool CBLSSecretKey::SecretKeyShare(const std::vector<CBLSSecretKey>& msk, const 
     }
 
     try {
-        impl = bls::BLS::PrivateKeyShare(mskVec, (const uint8_t*)_id.impl.begin());
+        impl = bls::Threshold::PrivateKeyShare(mskVec, bls::Bytes(_id.impl.begin(), _id.impl.size()));
     } catch (...) {
         return false;
     }
 
     fValid = true;
-    UpdateHash();
+    cachedHash.SetNull();
     return true;
 }
 
@@ -152,9 +108,9 @@ CBLSPublicKey CBLSSecretKey::GetPublicKey() const
     }
 
     CBLSPublicKey pubKey;
-    pubKey.impl = impl.GetPublicKey();
+    pubKey.impl = impl.GetG1Element();
     pubKey.fValid = true;
-    pubKey.UpdateHash();
+    pubKey.cachedHash.SetNull();
     return pubKey;
 }
 
@@ -165,67 +121,50 @@ CBLSSignature CBLSSecretKey::Sign(const uint256& hash) const
     }
 
     CBLSSignature sigRet;
-    sigRet.impl = impl.SignInsecurePrehashed((const uint8_t*)hash.begin());
+    sigRet.impl = Scheme(fLegacy)->Sign(impl, bls::Bytes(hash.begin(), hash.size()));
 
     sigRet.fValid = true;
-    sigRet.UpdateHash();
+    sigRet.cachedHash.SetNull();
 
     return sigRet;
-}
-
-bool CBLSPublicKey::InternalSetBuf(const void* buf)
-{
-    try {
-        impl = bls::PublicKey::FromBytes((const uint8_t*)buf);
-        return true;
-    } catch (...) {
-        return false;
-    }
-}
-
-bool CBLSPublicKey::InternalGetBuf(void* buf) const
-{
-    impl.Serialize((uint8_t*)buf);
-    return true;
 }
 
 void CBLSPublicKey::AggregateInsecure(const CBLSPublicKey& o)
 {
     assert(IsValid() && o.IsValid());
-    impl = bls::PublicKey::AggregateInsecure({impl, o.impl});
-    UpdateHash();
+    impl = Scheme(fLegacy)->Aggregate({impl, o.impl});
+    cachedHash.SetNull();
 }
 
-CBLSPublicKey CBLSPublicKey::AggregateInsecure(const std::vector<CBLSPublicKey>& pks)
+CBLSPublicKey CBLSPublicKey::AggregateInsecure(const std::vector<CBLSPublicKey>& pks, const bool fLegacy)
 {
     if (pks.empty()) {
         return CBLSPublicKey();
     }
 
-    std::vector<bls::PublicKey> v;
-    v.reserve(pks.size());
+    std::vector<bls::G1Element> vecPublicKeys;
+    vecPublicKeys.reserve(pks.size());
     for (auto& pk : pks) {
-        v.emplace_back(pk.impl);
+        vecPublicKeys.emplace_back(pk.impl);
     }
 
-    auto agg = bls::PublicKey::AggregateInsecure(v);
     CBLSPublicKey ret;
-    ret.impl = agg;
+    ret.impl = Scheme(fLegacy)->Aggregate(vecPublicKeys);
     ret.fValid = true;
-    ret.UpdateHash();
+    ret.cachedHash.SetNull();
     return ret;
 }
 
 bool CBLSPublicKey::PublicKeyShare(const std::vector<CBLSPublicKey>& mpk, const CBLSId& _id)
 {
     fValid = false;
-    UpdateHash();
+    cachedHash.SetNull();
 
     if (!_id.IsValid()) {
         return false;
     }
 
-    std::vector<bls::PublicKey> mpkVec;
+    std::vector<bls::G1Element> mpkVec;
     mpkVec.reserve(mpk.size());
     for (const CBLSPublicKey& pk : mpk) {
         if (!pk.IsValid()) {
@@ -235,102 +174,89 @@ bool CBLSPublicKey::PublicKeyShare(const std::vector<CBLSPublicKey>& mpk, const 
     }
 
     try {
-        impl = bls::BLS::PublicKeyShare(mpkVec, (const uint8_t*)_id.impl.begin());
+        impl = bls::Threshold::PublicKeyShare(mpkVec, bls::Bytes(_id.impl.begin(), _id.impl.size()));
     } catch (...) {
         return false;
     }
 
     fValid = true;
-    UpdateHash();
+    cachedHash.SetNull();
     return true;
 }
 
 bool CBLSPublicKey::DHKeyExchange(const CBLSSecretKey& sk, const CBLSPublicKey& pk)
 {
     fValid = false;
-    UpdateHash();
+    cachedHash.SetNull();
 
     if (!sk.IsValid() || !pk.IsValid()) {
         return false;
     }
-    impl = bls::BLS::DHKeyExchange(sk.impl, pk.impl);
+    impl = sk.impl * pk.impl;
     fValid = true;
-    UpdateHash();
-    return true;
-}
-
-bool CBLSSignature::InternalSetBuf(const void* buf)
-{
-    try {
-        impl = bls::InsecureSignature::FromBytes((const uint8_t*)buf);
-        return true;
-    } catch (...) {
-        return false;
-    }
-}
-
-bool CBLSSignature::InternalGetBuf(void* buf) const
-{
-    impl.Serialize((uint8_t*)buf);
+    cachedHash.SetNull();
     return true;
 }
 
 void CBLSSignature::AggregateInsecure(const CBLSSignature& o)
 {
     assert(IsValid() && o.IsValid());
-    impl = bls::InsecureSignature::Aggregate({impl, o.impl});
-    UpdateHash();
+    impl = Scheme(fLegacy)->Aggregate({impl, o.impl});
+    cachedHash.SetNull();
 }
 
-CBLSSignature CBLSSignature::AggregateInsecure(const std::vector<CBLSSignature>& sigs)
+CBLSSignature CBLSSignature::AggregateInsecure(const std::vector<CBLSSignature>& sigs, const bool fLegacy)
 {
     if (sigs.empty()) {
         return CBLSSignature();
     }
 
-    std::vector<bls::InsecureSignature> v;
+    std::vector<bls::G2Element> v;
     v.reserve(sigs.size());
     for (auto& pk : sigs) {
         v.emplace_back(pk.impl);
     }
 
-    auto agg = bls::InsecureSignature::Aggregate(v);
     CBLSSignature ret;
-    ret.impl = agg;
+    ret.impl = Scheme(fLegacy)->Aggregate(v);
     ret.fValid = true;
-    ret.UpdateHash();
+    ret.cachedHash.SetNull();
     return ret;
 }
 
 CBLSSignature CBLSSignature::AggregateSecure(const std::vector<CBLSSignature>& sigs,
                                              const std::vector<CBLSPublicKey>& pks,
-                                             const uint256& hash)
+                                             const uint256& hash,
+                                             const bool fLegacy)
 {
     if (sigs.size() != pks.size() || sigs.empty()) {
         return CBLSSignature();
     }
 
-    std::vector<bls::Signature> v;
-    v.reserve(sigs.size());
-
-    for (size_t i = 0; i < sigs.size(); i++) {
-        bls::AggregationInfo aggInfo = bls::AggregationInfo::FromMsgHash(pks[i].impl, hash.begin());
-        v.emplace_back(bls::Signature::FromInsecureSig(sigs[i].impl, aggInfo));
+    std::vector<bls::G1Element> vecPublicKeys;
+    vecPublicKeys.reserve(pks.size());
+    for (auto& pk : pks) {
+        vecPublicKeys.push_back(pk.impl);
     }
 
-    auto aggSig = bls::Signature::AggregateSigs(v);
+    std::vector<bls::G2Element> vecSignatures;
+    vecSignatures.reserve(pks.size());
+    for (auto& sig : sigs) {
+        vecSignatures.push_back(sig.impl);
+    }
+
     CBLSSignature ret;
-    ret.impl = aggSig.GetInsecureSig();
+    ret.impl = Scheme(fLegacy)->AggregateSecure(vecPublicKeys, vecSignatures, bls::Bytes(hash.begin(), hash.size()));
     ret.fValid = true;
-    ret.UpdateHash();
+    ret.cachedHash.SetNull();
     return ret;
 }
 
 void CBLSSignature::SubInsecure(const CBLSSignature& o)
 {
     assert(IsValid() && o.IsValid());
-    impl = impl.DivideBy({o.impl});
-    UpdateHash();
+    impl = impl + o.impl.Negate();
+    cachedHash.SetNull();
 }
 
 bool CBLSSignature::VerifyInsecure(const CBLSPublicKey& pubKey, const uint256& hash) const
@@ -340,7 +266,7 @@ bool CBLSSignature::VerifyInsecure(const CBLSPublicKey& pubKey, const uint256& h
     }
 
     try {
-        return impl.Verify({(const uint8_t*)hash.begin()}, {pubKey.impl});
+        return Scheme(fLegacy)->Verify(pubKey.impl, bls::Bytes(hash.begin(), hash.size()), impl);
     } catch (...) {
         return false;
     }
@@ -353,8 +279,8 @@ bool CBLSSignature::VerifyInsecureAggregated(const std::vector<CBLSPublicKey>& p
     }
     assert(!pubKeys.empty() && !hashes.empty() && pubKeys.size() == hashes.size());
 
-    std::vector<bls::PublicKey> pubKeyVec;
-    std::vector<const uint8_t*> hashes2;
+    std::vector<bls::G1Element> pubKeyVec;
+    std::vector<bls::Bytes> hashes2;
     hashes2.reserve(hashes.size());
     pubKeyVec.reserve(pubKeys.size());
     for (size_t i = 0; i < pubKeys.size(); i++) {
@@ -363,11 +289,11 @@ bool CBLSSignature::VerifyInsecureAggregated(const std::vector<CBLSPublicKey>& p
             return false;
         }
         pubKeyVec.push_back(p.impl);
-        hashes2.push_back((uint8_t*)hashes[i].begin());
+        hashes2.emplace_back(hashes[i].begin(), hashes[i].size());
     }
 
     try {
-        return impl.Verify(hashes2, pubKeyVec);
+        return Scheme(fLegacy)->AggregateVerify(pubKeyVec, hashes2, impl);
     } catch (...) {
         return false;
     }
@@ -379,29 +305,26 @@ bool CBLSSignature::VerifySecureAggregated(const std::vector<CBLSPublicKey>& pks
         return false;
     }
 
-    std::vector<bls::AggregationInfo> v;
-    v.reserve(pks.size());
-    for (auto& pk : pks) {
-        auto aggInfo = bls::AggregationInfo::FromMsgHash(pk.impl, hash.begin());
-        v.emplace_back(aggInfo);
+    std::vector<bls::G1Element> vecPublicKeys;
+    vecPublicKeys.reserve(pks.size());
+    for (const auto& pk : pks) {
+        vecPublicKeys.push_back(pk.impl);
     }
 
-    bls::AggregationInfo aggInfo = bls::AggregationInfo::MergeInfos(v);
-    bls::Signature aggSig = bls::Signature::FromInsecureSig(impl, aggInfo);
-    return aggSig.Verify();
+    return Scheme(fLegacy)->VerifySecure(vecPublicKeys, impl, bls::Bytes(hash.begin(), hash.size()));
 }
 
 bool CBLSSignature::Recover(const std::vector<CBLSSignature>& sigs, const std::vector<CBLSId>& ids)
 {
     fValid = false;
-    UpdateHash();
+    cachedHash.SetNull();
 
     if (sigs.empty() || ids.empty() || sigs.size() != ids.size()) {
         return false;
     }
 
-    std::vector<bls::InsecureSignature> sigsVec;
-    std::vector<const uint8_t*> idsVec;
+    std::vector<bls::G2Element> sigsVec;
+    std::vector<bls::Bytes> idsVec;
     sigsVec.reserve(sigs.size());
     idsVec.reserve(sigs.size());
 
@@ -410,17 +333,17 @@ bool CBLSSignature::Recover(const std::vector<CBLSSignature>& sigs, const std::v
             return false;
         }
         sigsVec.emplace_back(sigs[i].impl);
-        idsVec.emplace_back(ids[i].impl.begin());
+        idsVec.emplace_back(ids[i].impl.begin(), ids[i].impl.size());
     }
 
     try {
-        impl = bls::BLS::RecoverSig(sigsVec, idsVec);
+        impl = bls::Threshold::SignatureRecover(sigsVec, idsVec);
     } catch (...) {
         return false;
     }
 
     fValid = true;
-    UpdateHash();
+    cachedHash.SetNull();
     return true;
 }
 

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2018-2019 The Dash Core developers
-// Copyright (c) 2018-2020 The Ion Core developers
+// Copyright (c) 2018-2021 The Dash Core developers
+// Copyright (c) 2018-2021 The Ion Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -11,16 +11,21 @@
 #include <uint256.h>
 #include <utilstrencodings.h>
 
-#undef ERROR // chia BLS uses relic, which defines ERROR, which in turn causes win32/win64 builds to print many warnings
-#include <chiabls/bls.hpp>
-#include <chiabls/privatekey.hpp>
-#include <chiabls/publickey.hpp>
-#include <chiabls/signature.hpp>
+// bls-dash uses relic, which may define DEBUG and ERROR, which leads to many warnings in some build setups
+#undef ERROR
+#undef DEBUG
+#include <bls-dash/bls.hpp>
+#include <bls-dash/privatekey.hpp>
+#include <bls-dash/elements.hpp>
+#include <bls-dash/schemes.hpp>
+#include <bls-dash/threshold.hpp>
 #undef DOUBLE
 
 #include <array>
 #include <mutex>
 #include <unistd.h>
+
+static const bool fLegacyDefault{true};
 
 // reversed BLS12-381
 #define BLS_CURVE_ID_SIZE 32
@@ -38,6 +43,8 @@ class CBLSWrapper
     friend class CBLSPublicKey;
     friend class CBLSSignature;
 
+    bool fLegacy;
+
 protected:
     ImplType impl;
     bool fValid{false};
@@ -45,26 +52,15 @@ protected:
 
     inline constexpr size_t GetSerSize() const { return SerSize; }
 
-    virtual bool InternalSetBuf(const void* buf) = 0;
-    virtual bool InternalGetBuf(void* buf) const = 0;
-
 public:
     static const size_t SerSize = _SerSize;
 
-    CBLSWrapper()
+    CBLSWrapper(const bool fLegacyIn = fLegacyDefault) : fLegacy(fLegacyIn)
     {
-        struct NullHash {
-            uint256 hash;
-            NullHash() {
-                char buf[_SerSize];
-                memset(buf, 0, _SerSize);
-                CHashWriter ss(SER_GETHASH, 0);
-                ss.write(buf, _SerSize);
-                hash = ss.GetHash();
-            }
-        };
-        static NullHash nullHash;
-        cachedHash = nullHash.hash;
+    }
+    CBLSWrapper(const std::vector<unsigned char>& vecBytes, const bool fLegacyIn = fLegacyDefault) : CBLSWrapper<ImplType, _SerSize, C>(fLegacyIn)
+    {
+        SetByteVector(vecBytes);
     }
 
     CBLSWrapper(const CBLSWrapper& ref) = default;
@@ -74,12 +70,14 @@ public:
         std::swap(impl, ref.impl);
         std::swap(fValid, ref.fValid);
         std::swap(cachedHash, ref.cachedHash);
+        std::swap(fLegacy, ref.fLegacy);
     }
     CBLSWrapper& operator=(CBLSWrapper&& ref)
     {
         std::swap(impl, ref.impl);
         std::swap(fValid, ref.fValid);
         std::swap(cachedHash, ref.cachedHash);
+        std::swap(fLegacy, ref.fLegacy);
         return *this;
     }
 
@@ -97,62 +95,45 @@ public:
         return fValid;
     }
 
-    void SetBuf(const void* buf, size_t size)
+    void Reset()
     {
-        if (size != SerSize) {
+        *((C*)this) = C(fLegacy);
+    }
+
+    void SetByteVector(const std::vector<uint8_t>& vecBytes)
+    {
+        if (vecBytes.size() != SerSize) {
             Reset();
             return;
         }
 
-        if (std::all_of((const char*)buf, (const char*)buf + SerSize, [](char c) { return c == 0; })) {
+        if (std::all_of(vecBytes.begin(), vecBytes.end(), [](uint8_t c) { return c == 0; })) {
             Reset();
         } else {
-            fValid = InternalSetBuf(buf);
-            if (!fValid) {
+            try {
+                impl = ImplType::FromBytes(bls::Bytes(vecBytes), fLegacy);
+                fValid = true;
+            } catch (...) {
                 Reset();
             }
         }
-        UpdateHash();
+        cachedHash.SetNull();
     }
 
-    void Reset()
+    std::vector<uint8_t> ToByteVector() const
     {
-        *((C*)this) = C();
-    }
-
-    void GetBuf(void* buf, size_t size) const
-    {
-        assert(size == SerSize);
-
         if (!fValid) {
-            memset(buf, 0, SerSize);
-        } else {
-            bool ok = InternalGetBuf(buf);
-            assert(ok);
+            return std::vector<uint8_t>(SerSize, 0);
         }
-    }
-
-    template <typename T>
-    void SetBuf(const T& buf)
-    {
-        SetBuf(buf.data(), buf.size());
-    }
-
-    template <typename T>
-    void GetBuf(T& buf) const
-    {
-        buf.resize(GetSerSize());
-        GetBuf(buf.data(), buf.size());
+        return impl.Serialize(fLegacy);
     }
 
     const uint256& GetHash() const
     {
+        if (cachedHash.IsNull()) {
+            cachedHash = ::SerializeHash(*this);
+        }
         return cachedHash;
-    }
-
-    void UpdateHash() const
-    {
-        cachedHash = ::SerializeHash(*this);
     }
 
     bool SetHexStr(const std::string& str)
@@ -166,7 +147,7 @@ public:
             Reset();
             return false;
         }
-        SetBuf(b);
+        SetByteVector(b);
         return IsValid();
     }
 
@@ -179,27 +160,23 @@ public:
     template <typename Stream>
     inline void Serialize(Stream& s) const
     {
-        char buf[SerSize] = {0};
-        GetBuf(buf, SerSize);
-        s.write((const char*)buf, SerSize);
+        s.write((const char*)ToByteVector().data(), SerSize);
     }
     template <typename Stream>
     inline void Unserialize(Stream& s, bool checkMalleable = true)
     {
-        char buf[SerSize];
-        s.read((char*)buf, SerSize);
-        SetBuf(buf, SerSize);
+        std::vector<uint8_t> vecBytes(SerSize, 0);
+        s.read((char*)vecBytes.data(), SerSize);
+        SetByteVector(vecBytes);
 
-        if (checkMalleable && !CheckMalleable(buf, SerSize)) {
+        if (checkMalleable && !CheckMalleable(vecBytes)) {
             throw std::ios_base::failure("malleable BLS object");
         }
     }
 
-    inline bool CheckMalleable(void* buf, size_t size) const
+    inline bool CheckMalleable(const std::vector<uint8_t>& vecBytes) const
     {
-        char buf2[SerSize];
-        GetBuf(buf2, SerSize);
-        if (memcmp(buf, buf2, SerSize)) {
+        if (memcmp(vecBytes.data(), ToByteVector().data(), SerSize)) {
             // TODO not sure if this is actually possible with the BLS libs. I'm assuming here that somewhere deep inside
             // these libs masking might happen, so that 2 different binary representations could result in the same object
             // representation
@@ -210,30 +187,40 @@ public:
 
     inline std::string ToString() const
     {
-        std::vector<unsigned char> buf;
-        GetBuf(buf);
+        std::vector<uint8_t> buf = ToByteVector();
         return HexStr(buf.begin(), buf.end());
     }
 };
 
-class CBLSId : public CBLSWrapper<uint256, BLS_CURVE_ID_SIZE, CBLSId>
+struct CBLSIdImplicit : public uint256
+{
+    CBLSIdImplicit() {}
+    CBLSIdImplicit(const uint256& id)
+    {
+        memcpy(begin(), id.begin(), sizeof(uint256));
+    }
+    static CBLSIdImplicit FromBytes(const uint8_t* buffer, const bool fLegacy = false)
+    {
+        CBLSIdImplicit instance;
+        memcpy(instance.begin(), buffer, sizeof(CBLSIdImplicit));
+        return instance;
+    }
+    std::vector<uint8_t> Serialize(const bool fLegacy = false) const
+    {
+        return {begin(), end()};
+    }
+};
+
+class CBLSId : public CBLSWrapper<CBLSIdImplicit, BLS_CURVE_ID_SIZE, CBLSId>
 {
 public:
     using CBLSWrapper::operator=;
     using CBLSWrapper::operator==;
     using CBLSWrapper::operator!=;
+    using CBLSWrapper::CBLSWrapper;
 
     CBLSId() {}
-
-    void SetInt(int x);
-    void SetHash(const uint256& hash);
-
-    static CBLSId FromInt(int64_t i);
-    static CBLSId FromHash(const uint256& hash);
-
-protected:
-    bool InternalSetBuf(const void* buf);
-    bool InternalGetBuf(void* buf) const;
+    CBLSId(const uint256& nHash);
 };
 
 class CBLSSecretKey : public CBLSWrapper<bls::PrivateKey, BLS_CURVE_SECKEY_SIZE, CBLSSecretKey>
@@ -242,6 +229,7 @@ public:
     using CBLSWrapper::operator=;
     using CBLSWrapper::operator==;
     using CBLSWrapper::operator!=;
+    using CBLSWrapper::CBLSWrapper;
 
     CBLSSecretKey() {}
 
@@ -255,13 +243,9 @@ public:
 
     CBLSPublicKey GetPublicKey() const;
     CBLSSignature Sign(const uint256& hash) const;
-
-protected:
-    bool InternalSetBuf(const void* buf);
-    bool InternalGetBuf(void* buf) const;
 };
 
-class CBLSPublicKey : public CBLSWrapper<bls::PublicKey, BLS_CURVE_PUBKEY_SIZE, CBLSPublicKey>
+class CBLSPublicKey : public CBLSWrapper<bls::G1Element, BLS_CURVE_PUBKEY_SIZE, CBLSPublicKey>
 {
     friend class CBLSSecretKey;
     friend class CBLSSignature;
@@ -270,21 +254,19 @@ public:
     using CBLSWrapper::operator=;
     using CBLSWrapper::operator==;
     using CBLSWrapper::operator!=;
+    using CBLSWrapper::CBLSWrapper;
 
     CBLSPublicKey() {}
 
     void AggregateInsecure(const CBLSPublicKey& o);
-    static CBLSPublicKey AggregateInsecure(const std::vector<CBLSPublicKey>& pks);
+    static CBLSPublicKey AggregateInsecure(const std::vector<CBLSPublicKey>& pks, bool fLegacy = fLegacyDefault);
 
     bool PublicKeyShare(const std::vector<CBLSPublicKey>& mpk, const CBLSId& id);
     bool DHKeyExchange(const CBLSSecretKey& sk, const CBLSPublicKey& pk);
 
-protected:
-    bool InternalSetBuf(const void* buf);
-    bool InternalGetBuf(void* buf) const;
 };
 
-class CBLSSignature : public CBLSWrapper<bls::InsecureSignature, BLS_CURVE_SIG_SIZE, CBLSSignature>
+class CBLSSignature : public CBLSWrapper<bls::G2Element, BLS_CURVE_SIG_SIZE, CBLSSignature>
 {
     friend class CBLSSecretKey;
 
@@ -298,8 +280,8 @@ public:
     CBLSSignature& operator=(const CBLSSignature&) = default;
 
     void AggregateInsecure(const CBLSSignature& o);
-    static CBLSSignature AggregateInsecure(const std::vector<CBLSSignature>& sigs);
-    static CBLSSignature AggregateSecure(const std::vector<CBLSSignature>& sigs, const std::vector<CBLSPublicKey>& pks, const uint256& hash);
+    static CBLSSignature AggregateInsecure(const std::vector<CBLSSignature>& sigs, bool fLegacy = fLegacyDefault);
+    static CBLSSignature AggregateSecure(const std::vector<CBLSSignature>& sigs, const std::vector<CBLSPublicKey>& pks, const uint256& hash, bool fLegacy = fLegacyDefault);
 
     void SubInsecure(const CBLSSignature& o);
 
@@ -309,10 +291,6 @@ public:
     bool VerifySecureAggregated(const std::vector<CBLSPublicKey>& pks, const uint256& hash) const;
 
     bool Recover(const std::vector<CBLSSignature>& sigs, const std::vector<CBLSId>& ids);
-
-protected:
-    bool InternalSetBuf(const void* buf);
-    bool InternalGetBuf(void* buf) const;
 };
 
 #ifndef BUILD_BITCOIN_INTERNAL
@@ -322,7 +300,7 @@ class CBLSLazyWrapper
 private:
     mutable std::mutex mutex;
 
-    mutable char buf[BLSObject::SerSize];
+    mutable std::vector<uint8_t> vecBytes;
     mutable bool bufValid{false};
 
     mutable BLSObject obj;
@@ -331,9 +309,9 @@ private:
     mutable uint256 hash;
 
 public:
-    CBLSLazyWrapper()
+    CBLSLazyWrapper() :
+        vecBytes(BLSObject::SerSize, 0)
     {
-        memset(buf, 0, sizeof(buf));
         // the all-zero buf is considered a valid buf, but the resulting object will return false for IsValid
         bufValid = true;
     }
@@ -348,9 +326,9 @@ public:
         std::unique_lock<std::mutex> l(r.mutex);
         bufValid = r.bufValid;
         if (r.bufValid) {
-            memcpy(buf, r.buf, sizeof(buf));
+            vecBytes = r.vecBytes;
         } else {
-            memset(buf, 0, sizeof(buf));
+            std::fill(vecBytes.begin(), vecBytes.end(), 0);
         }
         objInitialized = r.objInitialized;
         if (r.objInitialized) {
@@ -375,21 +353,21 @@ public:
             throw std::ios_base::failure("obj and buf not initialized");
         }
         if (!bufValid) {
-            obj.GetBuf(buf, sizeof(buf));
+            vecBytes = obj.ToByteVector();
             bufValid = true;
-            hash = uint256();
+            hash.SetNull();
         }
-        s.write(buf, sizeof(buf));
+        s.write((const char*)vecBytes.data(), vecBytes.size());
     }
 
     template<typename Stream>
     inline void Unserialize(Stream& s)
     {
         std::unique_lock<std::mutex> l(mutex);
-        s.read(buf, sizeof(buf));
+        s.read((char*)vecBytes.data(), BLSObject::SerSize);
         bufValid = true;
         objInitialized = false;
-        hash = uint256();
+        hash.SetNull();
     }
 
     void Set(const BLSObject& _obj)
@@ -398,7 +376,7 @@ public:
         bufValid = false;
         objInitialized = true;
         obj = _obj;
-        hash = uint256();
+        hash.SetNull();
     }
     const BLSObject& Get() const
     {
@@ -408,8 +386,8 @@ public:
             return invalidObj;
         }
         if (!objInitialized) {
-            obj.SetBuf(buf, sizeof(buf));
-            if (!obj.CheckMalleable(buf, sizeof(buf))) {
+            obj.SetByteVector(vecBytes);
+            if (!obj.CheckMalleable(vecBytes)) {
                 bufValid = false;
                 objInitialized = false;
                 obj = invalidObj;
@@ -423,7 +401,7 @@ public:
     bool operator==(const CBLSLazyWrapper& r) const
     {
         if (bufValid && r.bufValid) {
-            return memcmp(buf, r.buf, sizeof(buf)) == 0;
+            return vecBytes == r.vecBytes;
         }
         if (objInitialized && r.objInitialized) {
             return obj == r.obj;
@@ -440,21 +418,16 @@ public:
     {
         std::unique_lock<std::mutex> l(mutex);
         if (!bufValid) {
-            obj.GetBuf(buf, sizeof(buf));
+            vecBytes = obj.ToByteVector();
             bufValid = true;
-            hash = uint256();
+            hash.SetNull();
         }
         if (hash.IsNull()) {
-            UpdateHash();
+            CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+            ss.write((const char*)vecBytes.data(), vecBytes.size());
+            hash = ss.GetHash();
         }
         return hash;
-    }
-private:
-    void UpdateHash() const
-    {
-        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-        ss.write(buf, sizeof(buf));
-        hash = ss.GetHash();
     }
 };
 typedef CBLSLazyWrapper<CBLSSignature> CBLSLazySignature;

--- a/src/bls/bls_batchverifier.h
+++ b/src/bls/bls_batchverifier.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 The Dash Core developers
+// Copyright (c) 2018-2020 The Dash Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/bls/bls_ies.cpp
+++ b/src/bls/bls_ies.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Dash Core developers
+// Copyright (c) 2018-2021 The Dash Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,7 +6,6 @@
 
 #include <hash.h>
 #include <random.h>
-#include <streams.h>
 
 #include <crypto/aes.h>
 
@@ -30,37 +29,50 @@ static bool DecryptBlob(const void* in, size_t inSize, Out& out, const void* sym
     return w == (int)inSize;
 }
 
-bool CBLSIESEncryptedBlob::Encrypt(const CBLSPublicKey& peerPubKey, const void* plainTextData, size_t dataSize)
+uint256 CBLSIESEncryptedBlob::GetIV(size_t idx) const
+{
+    uint256 iv = ivSeed;
+    for (size_t i = 0; i < idx; i++) {
+        iv = ::SerializeHash(iv);
+    }
+    return iv;
+}
+
+bool CBLSIESEncryptedBlob::Encrypt(size_t idx, const CBLSPublicKey& peerPubKey, const void* plainTextData, size_t dataSize)
 {
     CBLSSecretKey ephemeralSecretKey;
     ephemeralSecretKey.MakeNewKey();
     ephemeralPubKey = ephemeralSecretKey.GetPublicKey();
-    GetStrongRandBytes(iv, sizeof(iv));
 
     CBLSPublicKey pk;
     if (!pk.DHKeyExchange(ephemeralSecretKey, peerPubKey)) {
         return false;
     }
 
-    std::vector<unsigned char> symKey;
-    pk.GetBuf(symKey);
+    std::vector<unsigned char> symKey = pk.ToByteVector();
     symKey.resize(32);
 
-    return EncryptBlob(plainTextData, dataSize, data, symKey.data(), iv);
+    uint256 iv = GetIV(idx);
+    return EncryptBlob(plainTextData, dataSize, data, symKey.data(), iv.begin());
 }
 
-bool CBLSIESEncryptedBlob::Decrypt(const CBLSSecretKey& secretKey, CDataStream& decryptedDataRet) const
+bool CBLSIESEncryptedBlob::Decrypt(size_t idx, const CBLSSecretKey& secretKey, CDataStream& decryptedDataRet) const
 {
     CBLSPublicKey pk;
     if (!pk.DHKeyExchange(secretKey, ephemeralPubKey)) {
         return false;
     }
 
-    std::vector<unsigned char> symKey;
-    pk.GetBuf(symKey);
+    std::vector<unsigned char> symKey = pk.ToByteVector();
     symKey.resize(32);
 
-    return DecryptBlob(data.data(), data.size(), decryptedDataRet, symKey.data(), iv);
+    uint256 iv = GetIV(idx);
+    return DecryptBlob(data.data(), data.size(), decryptedDataRet, symKey.data(), iv.begin());
+}
+
+bool CBLSIESEncryptedBlob::IsValid() const
+{
+    return ephemeralPubKey.IsValid() && data.size() > 0 && !ivSeed.IsNull();
 }
 
 
@@ -105,8 +117,7 @@ bool CBLSIESMultiRecipientBlobs::Encrypt(size_t idx, const CBLSPublicKey& recipi
         return false;
     }
 
-    std::vector<unsigned char> symKey;
-    pk.GetBuf(symKey);
+    std::vector<uint8_t> symKey = pk.ToByteVector();
     symKey.resize(32);
 
     return EncryptBlob(blob.data(), blob.size(), blobs[idx], symKey.data(), ivVector[idx].begin());
@@ -123,8 +134,7 @@ bool CBLSIESMultiRecipientBlobs::Decrypt(size_t idx, const CBLSSecretKey& sk, Bl
         return false;
     }
 
-    std::vector<unsigned char> symKey;
-    pk.GetBuf(symKey);
+    std::vector<uint8_t> symKey = pk.ToByteVector();
     symKey.resize(32);
 
     uint256 iv = ivSeed;

--- a/src/bls/bls_ies.h
+++ b/src/bls/bls_ies.h
@@ -1,4 +1,5 @@
-// Copyright (c) 2018 The Dash Core developers
+// Copyright (c) 2018-2021 The Dash Core developers
+// Copyright (c) 2018-2021 The Ion Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,10 +13,10 @@ class CBLSIESEncryptedBlob
 {
 public:
     CBLSPublicKey ephemeralPubKey;
-    unsigned char iv[16];
+    uint256 ivSeed;
     std::vector<unsigned char> data;
 
-    bool valid{false};
+    uint256 GetIV(size_t idx) const;
 
 public:
     ADD_SERIALIZE_METHODS
@@ -23,22 +24,15 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
-        if (!ser_action.ForRead()) {
-            assert(valid);
-        } else {
-            valid = false;
-        }
         READWRITE(ephemeralPubKey);
-        READWRITE(FLATDATA(iv));
+        READWRITE(ivSeed);
         READWRITE(data);
-        if (ser_action.ForRead()) {
-            valid = true;
-        }
-    };
+    }
 
 public:
-    bool Encrypt(const CBLSPublicKey& peerPubKey, const void* data, size_t dataSize);
-    bool Decrypt(const CBLSSecretKey& secretKey, CDataStream& decryptedDataRet) const;
+    bool Encrypt(size_t idx, const CBLSPublicKey& peerPubKey, const void* data, size_t dataSize);
+    bool Decrypt(size_t idx, const CBLSSecretKey& secretKey, CDataStream& decryptedDataRet) const;
+    bool IsValid() const;
 };
 
 template <typename Object>
@@ -49,21 +43,28 @@ public:
     {
     }
 
-    bool Encrypt(const CBLSPublicKey& peerPubKey, const Object& obj, int nVersion)
+    CBLSIESEncryptedObject(const CBLSPublicKey& ephemeralPubKeyIn, const uint256& ivSeedIn, const std::vector<unsigned char>& dataIn)
+    {
+        ephemeralPubKey = ephemeralPubKeyIn;
+        ivSeed = ivSeedIn;
+        data = dataIn;
+    }
+
+    bool Encrypt(size_t idx, const CBLSPublicKey& peerPubKey, const Object& obj, int nVersion)
     {
         try {
             CDataStream ds(SER_NETWORK, nVersion);
             ds << obj;
-            return CBLSIESEncryptedBlob::Encrypt(peerPubKey, ds.data(), ds.size());
+            return CBLSIESEncryptedBlob::Encrypt(idx, peerPubKey, ds.data(), ds.size());
         } catch (std::exception&) {
             return false;
         }
     }
 
-    bool Decrypt(const CBLSSecretKey& secretKey, Object& objRet, int nVersion) const
+    bool Decrypt(size_t idx, const CBLSSecretKey& secretKey, Object& objRet, int nVersion) const
     {
         CDataStream ds(SER_NETWORK, nVersion);
-        if (!CBLSIESEncryptedBlob::Decrypt(secretKey, ds)) {
+        if (!CBLSIESEncryptedBlob::Decrypt(idx, secretKey, ds)) {
             return false;
         }
         try {
@@ -158,6 +159,11 @@ public:
         } catch (std::exception&) {
             return false;
         }
+    }
+
+    CBLSIESEncryptedObject<Object> Get(const size_t idx)
+    {
+        return {ephemeralPubKey, ivSeed, blobs[idx]};
     }
 };
 

--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 The Dash Core developers
+// Copyright (c) 2018-2021 The Dash Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -63,7 +63,7 @@ void CBLSWorker::Start()
     int workerCount = std::thread::hardware_concurrency() / 2;
     workerCount = std::max(std::min(1, workerCount), 4);
     workerPool.resize(workerCount);
-    RenameThreadPool(workerPool, "ion-bls-worker");
+    RenameThreadPool(workerPool, "bytz-bls-work");
 }
 
 void CBLSWorker::Stop()
@@ -72,11 +72,11 @@ void CBLSWorker::Stop()
     workerPool.stop(true);
 }
 
-bool CBLSWorker::GenerateContributions(int quorumThreshold, const BLSIdVector& ids, BLSVerificationVectorPtr& vvecRet, BLSSecretKeyVector& skShares)
+bool CBLSWorker::GenerateContributions(int quorumThreshold, const BLSIdVector& ids, BLSVerificationVectorPtr& vvecRet, BLSSecretKeyVector& skSharesRet)
 {
     BLSSecretKeyVectorPtr svec = std::make_shared<BLSSecretKeyVector>((size_t)quorumThreshold);
     vvecRet = std::make_shared<BLSVerificationVector>((size_t)quorumThreshold);
-    skShares.resize(ids.size());
+    skSharesRet.resize(ids.size());
 
     for (int i = 0; i < quorumThreshold; i++) {
         (*svec)[i].MakeNewKey();
@@ -101,7 +101,7 @@ bool CBLSWorker::GenerateContributions(int quorumThreshold, const BLSIdVector& i
         size_t count = std::min(batchSize, ids.size() - start);
         auto f = [&, start, count](int threadId) {
             for (size_t j = start; j < start + count; j++) {
-                if (!skShares[j].SecretKeyShare(*svec, ids[j])) {
+                if (!skSharesRet[j].SecretKeyShare(*svec, ids[j])) {
                     return false;
                 }
             }
@@ -404,7 +404,7 @@ struct ContributionVerifier {
         BLSVerificationVectorPtr vvec;
         CBLSSecretKey skShare;
 
-        // starts with 0 and is incremented if either vvec or skShare aggregation finishes. If it reaches 2, we know
+        // starts with 0 and is incremented if either vvec or skShare aggregation finishs. If it reaches 2, we know
         // that aggregation for this batch is fully done. We can then start verification.
         std::unique_ptr<std::atomic<int> > aggDone;
 

--- a/src/bls/bls_worker.h
+++ b/src/bls/bls_worker.h
@@ -1,4 +1,5 @@
-// Copyright (c) 2018-2020 The Dash Core developers
+// Copyright (c) 2018-2021 The Dash Core developers
+// Copyright (c) 2018-2021 The Ion Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -56,7 +57,7 @@ public:
     void Start();
     void Stop();
 
-    bool GenerateContributions(int threshold, const BLSIdVector& ids, BLSVerificationVectorPtr& vvecRet, BLSSecretKeyVector& skShares);
+    bool GenerateContributions(int threshold, const BLSIdVector& ids, BLSVerificationVectorPtr& vvecRet, BLSSecretKeyVector& skSharesRet);
 
     // The following functions are all used to aggregate verification (public key) vectors
     // Inputs are in the following form:
@@ -82,7 +83,7 @@ public:
     // Inputs are in the following form:
     //   [a, b, c, d],
     // The result is simply a+b+c+d
-    // Aggregation is parallelized by splitting up the input vector into multiple batches and then aggregating the individual batch results
+    // Aggregation is paralellized by splitting up the input vector into multiple batches and then aggregating the individual batch results
     void AsyncAggregateSecretKeys(const BLSSecretKeyVector& secKeys,
                                   size_t start, size_t count, bool parallel,
                                   std::function<void(const CBLSSecretKey&)> doneCallback);

--- a/src/governance/governance-object.cpp
+++ b/src/governance/governance-object.cpp
@@ -306,18 +306,16 @@ void CGovernanceObject::SetMasternodeOutpoint(const COutPoint& outpoint)
 bool CGovernanceObject::Sign(const CBLSSecretKey& key)
 {
     CBLSSignature sig = key.Sign(GetSignatureHash());
-    if (!key.IsValid()) {
+    if (!sig.IsValid()) {
         return false;
     }
-    sig.GetBuf(vchSig);
+    vchSig = sig.ToByteVector();
     return true;
 }
 
 bool CGovernanceObject::CheckSignature(const CBLSPublicKey& pubKey) const
 {
-    CBLSSignature sig;
-    sig.SetBuf(vchSig);
-    if (!sig.VerifyInsecure(pubKey, GetSignatureHash())) {
+    if (!CBLSSignature(vchSig).VerifyInsecure(pubKey, GetSignatureHash())) {
         LogPrintf("CGovernanceObject::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }

--- a/src/governance/governance-vote.cpp
+++ b/src/governance/governance-vote.cpp
@@ -229,21 +229,20 @@ bool CGovernanceVote::Sign(const CBLSSecretKey& key)
     if (!sig.IsValid()) {
         return false;
     }
-    sig.GetBuf(vchSig);
+    vchSig = sig.ToByteVector();
     return true;
 }
 
+
 bool CGovernanceVote::CheckSignature(const CBLSPublicKey& pubKey) const
 {
-    uint256 hash = GetSignatureHash();
-    CBLSSignature sig;
-    sig.SetBuf(vchSig);
-    if (!sig.VerifyInsecure(pubKey, hash)) {
+    if (!CBLSSignature(vchSig).VerifyInsecure(pubKey, GetSignatureHash())) {
         LogPrintf("CGovernanceVote::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }
     return true;
 }
+
 
 bool CGovernanceVote::IsValid(bool useVotingKey) const
 {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2190,8 +2190,7 @@ bool AppInitMain()
     std::string strMasterNodeBLSPrivKey = gArgs.GetArg("-masternodeblsprivkey", "");
     if (!strMasterNodeBLSPrivKey.empty()) {
         auto binKey = ParseHex(strMasterNodeBLSPrivKey);
-        CBLSSecretKey keyOperator;
-        keyOperator.SetBuf(binKey);
+        CBLSSecretKey keyOperator(binKey);
         if (!keyOperator.IsValid()) {
             return InitError(_("Invalid masternodeblsprivkey. Please see documentation."));
         }

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -85,7 +85,7 @@ CBLSPublicKey CQuorum::GetPubKeyShare(size_t memberIdx) const
         return CBLSPublicKey();
     }
     auto& m = members[memberIdx];
-    return blsCache.BuildPubKeyShare(m->proTxHash, quorumVvec, CBLSId::FromHash(m->proTxHash));
+    return blsCache.BuildPubKeyShare(m->proTxHash, quorumVvec, CBLSId(m->proTxHash));
 }
 
 CBLSSecretKey CQuorum::GetSkShare() const

--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -84,7 +84,7 @@ CDKGPrematureCommitment::CDKGPrematureCommitment(const Consensus::LLMQParams& pa
 CDKGMember::CDKGMember(CDeterministicMNCPtr _dmn, size_t _idx) :
     dmn(_dmn),
     idx(_idx),
-    id(CBLSId::FromHash(_dmn->proTxHash))
+    id(_dmn->proTxHash)
 {
 
 }
@@ -1021,16 +1021,15 @@ void CDKGSession::SendCommitment(CDKGPendingMessages& pendingMessages)
     qc.quorumSig = skShare.Sign(commitmentHash);
 
     if (lieType == 3) {
-        std::vector<unsigned char> buf;
-        qc.sig.GetBuf(buf);
+        std::vector<uint8_t> buf = qc.sig.ToByteVector();
         buf[5]++;
-        qc.sig.SetBuf(buf);
+        qc.sig.SetByteVector(buf);
     } else if (lieType == 4) {
-        std::vector<unsigned char> buf;
-        qc.quorumSig.GetBuf(buf);
+        std::vector<uint8_t> buf = qc.quorumSig.ToByteVector();
         buf[5]++;
-        qc.quorumSig.SetBuf(buf);
+        qc.quorumSig.SetByteVector(buf);
     }
+
 
     t3.stop();
     timerTotal.stop();

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -809,7 +809,7 @@ void CSigSharesManager::TryRecoverSig(const CQuorumCPtr& quorum, const uint256& 
         for (auto it = sigShares->begin(); it != sigShares->end() && sigSharesForRecovery.size() < quorum->params.threshold; ++it) {
             auto& sigShare = it->second;
             sigSharesForRecovery.emplace_back(sigShare.sigShare.Get());
-            idsForRecovery.emplace_back(CBLSId::FromHash(quorum->members[sigShare.quorumMember]->proTxHash));
+            idsForRecovery.emplace_back(quorum->members[sigShare.quorumMember]->proTxHash);
         }
 
         // check if we can recover the final signature

--- a/src/privatesend/privatesend.cpp
+++ b/src/privatesend/privatesend.cpp
@@ -45,15 +45,13 @@ uint256 CPrivateSendQueue::GetSignatureHash() const
 bool CPrivateSendQueue::Sign()
 {
     if (!fMasternodeMode) return false;
-
-
+    
     uint256 hash = GetSignatureHash();
     CBLSSignature sig = activeMasternodeInfo.blsKeyOperator->Sign(hash);
     if (!sig.IsValid()) {
         return false;
     }
-    sig.GetBuf(vchSig);
-
+    vchSig = sig.ToByteVector();
     return true;
 }
 
@@ -62,12 +60,10 @@ bool CPrivateSendQueue::CheckSignature(const CBLSPublicKey& blsPubKey) const
     uint256 hash = GetSignatureHash();
 
     CBLSSignature sig;
-    sig.SetBuf(vchSig);
-    if (!sig.IsValid() || !sig.VerifyInsecure(blsPubKey, hash)) {
-        LogPrint(BCLog::PRIVATESEND, "CPrivateSendQueue::CheckSignature -- VerifyInsecure() failed\n");
+    if (!CBLSSignature(vchSig).VerifyInsecure(blsPubKey, GetSignatureHash())) {
+        LogPrintf("CPrivateSendQueue::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }
-
     return true;
 }
 
@@ -102,8 +98,7 @@ bool CPrivateSendBroadcastTx::Sign()
     if (!sig.IsValid()) {
         return false;
     }
-    sig.GetBuf(vchSig);
-
+    vchSig = sig.ToByteVector();
     return true;
 }
 
@@ -112,12 +107,10 @@ bool CPrivateSendBroadcastTx::CheckSignature(const CBLSPublicKey& blsPubKey) con
     uint256 hash = GetSignatureHash();
 
     CBLSSignature sig;
-    sig.SetBuf(vchSig);
-    if (!sig.IsValid() || !sig.VerifyInsecure(blsPubKey, hash)) {
-        LogPrint(BCLog::PRIVATESEND, "CPrivateSendBroadcastTx::CheckSignature -- VerifyInsecure() failed\n");
+    if (!CBLSSignature(vchSig).VerifyInsecure(blsPubKey, GetSignatureHash())) {
+        LogPrintf("CPrivateSendBroadcastTx::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }
-
     return true;
 }
 

--- a/src/test/evo_simplifiedmns_tests.cpp
+++ b/src/test/evo_simplifiedmns_tests.cpp
@@ -23,13 +23,10 @@ BOOST_AUTO_TEST_CASE(simplifiedmns_merkleroots)
         std::string ip = strprintf("%d.%d.%d.%d", 0, 0, 0, i);
         Lookup(ip.c_str(), smle.service, i, false);
 
-        uint8_t skBuf[CBLSSecretKey::SerSize];
-        memset(skBuf, 0, sizeof(skBuf));
-        skBuf[0] = (uint8_t)i;
-        CBLSSecretKey sk;
-        sk.SetBuf(skBuf, sizeof(skBuf));
+       std::vector<unsigned char> vecBytes{static_cast<unsigned char>(i)};
+        vecBytes.resize(CBLSSecretKey::SerSize);
 
-        smle.pubKeyOperator.Set(sk.GetPublicKey());
+        smle.pubKeyOperator.Set(CBLSSecretKey(vecBytes).GetPublicKey());
         smle.keyIDVoting.SetHex(strprintf("%040x", i));
         smle.isValid = true;
 


### PR DESCRIPTION
chia-bls does not compile with gcc > 10 so we are now using dash's bls-dash instead

Two patches for other depends:

xcb_proto does not compile with the newest version of python due to deprecated gcd function
qt does not compile without bootstrap configuration set